### PR TITLE
Add simple FiveM loading screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Hawk Loading Screen
+
+This repository contains a simple loading screen for FiveM servers.
+
+## Usage
+
+1. Place this resource in your FiveM `resources` folder.
+2. Add `ensure Hawk_Loading` to your `server.cfg`.
+
+The loading screen will show a basic progress bar while clients connect.

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,0 +1,14 @@
+fx_version 'cerulean'
+game 'gta5'
+
+author 'Hawk'
+
+description 'Simple loading screen'
+
+files {
+    'html/index.html',
+    'html/styles.css',
+    'html/script.js'
+}
+
+loadscreen 'html/index.html'

--- a/html/index.html
+++ b/html/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hawk Loading</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="loading-container">
+    <h1>Welcome to Hawk Server</h1>
+    <div id="progress-wrapper">
+      <div id="progress-bar"></div>
+    </div>
+    <p id="loading-text">Loading...</p>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/html/script.js
+++ b/html/script.js
@@ -1,0 +1,19 @@
+// Simple fake progress bar
+let progress = 0;
+const progressBar = document.getElementById('progress-bar');
+const loadingText = document.getElementById('loading-text');
+
+function update() {
+  progress += Math.random() * 5;
+  if (progress > 100) progress = 100;
+  progressBar.style.width = progress + '%';
+  loadingText.textContent = 'Loading... ' + Math.floor(progress) + '%';
+
+  if (progress < 100) {
+    requestAnimationFrame(update);
+  } else {
+    loadingText.textContent = 'Ready!';
+  }
+}
+
+requestAnimationFrame(update);

--- a/html/styles.css
+++ b/html/styles.css
@@ -1,0 +1,31 @@
+body {
+  margin: 0;
+  padding: 0;
+  background-color: #1e272e;
+  color: #fff;
+  font-family: Arial, Helvetica, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+#loading-container {
+  text-align: center;
+}
+
+#progress-wrapper {
+  width: 80%%;
+  background-color: #333;
+  border-radius: 4px;
+  overflow: hidden;
+  margin: 20px auto;
+  height: 20px;
+}
+
+#progress-bar {
+  height: 100%%;
+  width: 0%%;
+  background-color: #44bd32;
+  transition: width 0.3s ease;
+}


### PR DESCRIPTION
## Summary
- create `fxmanifest.lua` to define loading screen files
- add basic HTML, CSS and JS for the loading screen
- document usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a338eb68c8330acfb49704eb2fae9